### PR TITLE
Add profile-me service and integrate with profile page

### DIFF
--- a/src/app/infrastructure/dtos/profile-me.dto.ts
+++ b/src/app/infrastructure/dtos/profile-me.dto.ts
@@ -1,0 +1,49 @@
+export interface SocialLink {
+  platform: string;
+  url: string;
+}
+
+export interface Link {
+  title: string;
+  url: string;
+}
+
+export interface Attachment {
+  title: string;
+  description: string;
+  mediaType: 'PHOTO' | 'VIDEO' | 'DOCUMENT';
+  data: string;
+}
+
+export interface InfluencerProfileResponse {
+  id: number;
+  name: string;
+  niches: string[];
+  bio: string;
+  country: string;
+  photo: string;
+  profilePhoto: string;
+  followers: number;
+  socialLinks: SocialLink[];
+  location: string;
+  links: Link[];
+  attachments: Attachment[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BrandProfileResponse {
+  id: number;
+  name: string;
+  sector: string;
+  country: string;
+  description: string;
+  logo: string;
+  profilePhoto: string;
+  websiteUrl: string;
+  location: string;
+  links: Link[];
+  attachments: Attachment[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/app/infrastructure/services/profile-me.service.ts
+++ b/src/app/infrastructure/services/profile-me.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { InfluencerProfileResponse, BrandProfileResponse } from '../dtos/profile-me.dto';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProfileMeService {
+  private readonly baseUrl = environment.apiBase;
+
+  constructor(private http: HttpClient) {}
+
+  private getHeaders(): HttpHeaders {
+    const token = localStorage.getItem('accessToken') || localStorage.getItem('access_token');
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  getInfluencerProfile(): Observable<InfluencerProfileResponse> {
+    return this.http.get<InfluencerProfileResponse>(`${this.baseUrl}/profiles/influencer/me`, {
+      headers: this.getHeaders()
+    });
+  }
+
+  getBrandProfile(): Observable<BrandProfileResponse> {
+    return this.http.get<BrandProfileResponse>(`${this.baseUrl}/profiles/brand/me`, {
+      headers: this.getHeaders()
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- define DTOs for retrieving current user's profile
- add `ProfileMeService` to fetch `/profiles/brand/me` and `/profiles/influencer/me`
- update profile page to use the new service and token-based requests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ade36b0832eb6651331bf283fb7